### PR TITLE
Fix/strengthen link between schema and target

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ _https://en.wikipedia.org/wiki/Morphism_
   - [Docs](#docs)
     - [1. The Schema](#1-the-schema)
       - [Schema Example](#schema-example)
+      - [1.1 Using a strict Schema](#11-using-a-strict-schema)
     - [2. Morphism as Currying Function](#2-morphism-as-currying-function)
       - [API](#api)
       - [Currying Function Example](#currying-function-example)
@@ -173,6 +174,24 @@ morphism(schema, input);
 ⏩ [More Schema examples](#more-schema-examples-%F0%9F%92%A1)
 
 📚 [Schema Docs](https://morphism.now.sh/interfaces/morphism.schema)
+
+#### 1.1 Using a strict Schema
+
+You might want to enforce the keys provided in your schema using `Typescript`. This is possible using a `StrictSchema`. Doing so will require to map every field of the `Target` type provided.
+
+```ts
+interface IFoo {
+  foo: string;
+  bar: number;
+}
+const schema: StrictSchema<IFoo> = { foo: 'qux', bar: () => 'test' };
+const source = { qux: 'foo' };
+const target = morphism(schema, source);
+// {
+//   "foo": "qux",
+//   "bar": "test"
+// }
+```
 
 ### 2. Morphism as Currying Function
 

--- a/src/morphism.spec.ts
+++ b/src/morphism.spec.ts
@@ -79,7 +79,7 @@ describe('Morphism', () => {
     });
 
     it('should throw an exception when trying to access a path from an undefined object', function() {
-      Morphism.setMapper(User, {
+      Morphism.setMapper<User, any>(User, {
         fieldWillThrow: {
           path: 'fieldWillThrow.becauseNotReachable',
           fn: (object: any) => {
@@ -97,7 +97,7 @@ describe('Morphism', () => {
 
     it('should rethrow an exception when applying a function on path throws an error', function() {
       const err = new TypeError('an internal error');
-      Morphism.setMapper(User, {
+      Morphism.setMapper<User, any>(User, {
         fieldWillThrow: {
           path: 'fieldWillThrow',
           fn: () => {
@@ -481,7 +481,7 @@ describe('Morphism', () => {
     });
 
     it('should return undefined if undefined is given to map without doing any processing', function() {
-      Morphism.register(User, { a: 'firstName' });
+      Morphism.register<User, any>(User, { a: 'firstName' });
       expect(Morphism.map(User, undefined)).toEqual(undefined);
     });
 

--- a/src/morphism.ts
+++ b/src/morphism.ts
@@ -150,9 +150,14 @@ function transformValuesFromObject<TDestination, Source>(
  * @param  {Array} items Items to be forwarded to Actions
  * @param  {} objectToCompute Created tranformed object of a given type
  */
-function transformValuesFromObject<TDestination, Source>(object: Source, schema: Schema, items: Source[], objectToCompute: TDestination) {
+function transformValuesFromObject<TDestination, Source>(
+  object: Source,
+  schema: Schema<TDestination>,
+  items: Source[],
+  objectToCompute: TDestination
+) {
   return Object.entries(schema)
-    .map(([targetProperty, action]) => {
+    .map(([targetProperty, action]: [string, SchemaActions]) => {
       // iterate on every action of the schema
       if (isString(action)) {
         // Action<String>: string path => [ target: 'source' ]
@@ -209,10 +214,10 @@ interface Mapper<Target> {
   <Source>(source: Source): Target;
 }
 
-function transformItems<T, TSchema extends Schema>(schema: TSchema): Mapper<{ [P in keyof TSchema]: any }>;
-function transformItems<T, TSchema extends Schema>(schema: TSchema, type: Constructable<T>): Mapper<{ [P in keyof TSchema]: any }>;
+function transformItems<T, TSchema extends Schema<T>>(schema: TSchema): Mapper<{ [P in keyof TSchema]: any }>;
+function transformItems<T, TSchema extends Schema<T>>(schema: TSchema, type: Constructable<T>): Mapper<{ [P in keyof TSchema]: any }>;
 
-function transformItems<T, TSchema extends Schema>(schema: TSchema, type?: Constructable<T>) {
+function transformItems<T, TSchema extends Schema<T>>(schema: TSchema, type?: Constructable<T>) {
   function mapper(source: any): any {
     if (!source) {
       return source;
@@ -242,7 +247,7 @@ function transformItems<T, TSchema extends Schema>(schema: TSchema, type?: Const
   return mapper;
 }
 
-function getSchemaForType<T>(type: Constructable<T>, baseSchema: Schema): Schema {
+function getSchemaForType<T>(type: Constructable<T>, baseSchema: Schema<T>): Schema<T> {
   let typeFields = Object.keys(new type());
   let defaultSchema = zipObject(typeFields, typeFields);
   let finalSchema = Object.assign(defaultSchema, baseSchema);
@@ -271,24 +276,24 @@ function getSchemaForType<T>(type: Constructable<T>, baseSchema: Schema): Schema
  * @param  {} type
  *
  */
-export function morphism<TSchema extends Schema>(schema: TSchema, items: any[]): { [P in keyof TSchema]: any }[]; // morphism<Target>({},[]) => {}[]
-export function morphism<TSchema extends Schema>(schema: TSchema, items: any): { [P in keyof TSchema]: any }; // morphism({},{}) => {}
+export function morphism<TSchema extends Schema<any>>(schema: TSchema, items: any[]): { [P in keyof TSchema]: any }[]; // morphism<Target>({},[]) => {}[]
+export function morphism<TSchema extends Schema<any>>(schema: TSchema, items: any): { [P in keyof TSchema]: any }; // morphism({},{}) => {}
 
-export function morphism<Target>(schema: Schema, items: any[]): Target[]; // morphism<Target>({},[]) => Target[]
-export function morphism<Target>(schema: Schema, items: any): Target; // morphism<Target>({},{}) => Target
+export function morphism<Target>(schema: Schema<Target>, items: any[]): Target[]; // morphism<Target>({},[]) => Target[]
+export function morphism<Target>(schema: Schema<Target>, items: any): Target; // morphism<Target>({},{}) => Target
 
-export function morphism<TSchema extends Schema>(schema: TSchema): Mapper<{ [P in keyof TSchema]: any }>; // morphism(TSchema) => mapper(S[]) => (keyof TSchema)[]
+export function morphism<TSchema extends Schema<any>>(schema: TSchema): Mapper<{ [P in keyof TSchema]: any }>; // morphism(TSchema) => mapper(S[]) => (keyof TSchema)[]
 
-export function morphism<Target>(schema: Schema): Mapper<Target>; // morphism<ITarget>({}) => Mapper<ITarget> => ITarget
+export function morphism<Target>(schema: Schema<Target>): Mapper<Target>; // morphism<ITarget>({}) => Mapper<ITarget> => ITarget
 
-export function morphism(schema: Schema, items: null): undefined; // Reflects a specific use case where Morphism({}, null) return undefined
+export function morphism(schema: Schema<any>, items: null): undefined; // Reflects a specific use case where Morphism({}, null) return undefined
 export function morphism(schema: null, items: {}): undefined; // Reflects a specific use case where Morphism(null, {}) return undefined
 
-export function morphism<Target, Source>(schema: Schema, items: null, type: Constructable<Target>): Mapper<Target>; // morphism({}, null, T) => mapper(S) => T
-export function morphism<Target, Source>(schema: Schema, items: Source[], type: Constructable<Target>): Target[]; // morphism({}, [], T) => T[]
-export function morphism<Target, Source>(schema: Schema, items: Source, type: Constructable<Target>): Target; // morphism({}, {}, T) => T
+export function morphism<Target, Source>(schema: Schema<Target>, items: null, type: Constructable<Target>): Mapper<Target>; // morphism({}, null, T) => mapper(S) => T
+export function morphism<Target, Source>(schema: Schema<Target>, items: Source[], type: Constructable<Target>): Target[]; // morphism({}, [], T) => T[]
+export function morphism<Target, Source>(schema: Schema<Target>, items: Source, type: Constructable<Target>): Target; // morphism({}, {}, T) => T
 
-export function morphism<Target, Source>(schema: Schema, items?: Source, type?: Constructable<Target>) {
+export function morphism<Target, Source>(schema: Schema<Target>, items?: Source, type?: Constructable<Target>) {
   if (items === undefined && type === undefined) {
     return transformItems(schema);
   } else if (schema && items && type) {
@@ -315,7 +320,7 @@ export interface IMorphismRegistry {
    * @param schema Structure-preserving object from a source data towards a target data.
    *
    */
-  register<Target, TSchema extends Schema>(type: Constructable<Target>, schema?: TSchema): Mapper<Target>;
+  register<Target, TSchema extends Schema<Target>>(type: Constructable<Target>, schema?: TSchema): Mapper<Target>;
   /**
    * Transform any input in the specified Class
    *
@@ -340,7 +345,7 @@ export interface IMorphismRegistry {
    * @param {Schema} schema Class Type of the ouput Data
    *
    */
-  setMapper<Target, TSchema extends Schema>(type: Constructable<Target>, schema: TSchema): Mapper<Target>;
+  setMapper<Target, TSchema extends Schema<Target>>(type: Constructable<Target>, schema: TSchema): Mapper<Target>;
   /**
    * Delete a registered schema associated to a Class
    *
@@ -384,7 +389,7 @@ export class MorphismRegistry implements IMorphismRegistry {
    * @param schema Structure-preserving object from a source data towards a target data.
    *
    */
-  register<Target, TSchema extends Schema>(type: Constructable<Target>, schema?: TSchema) {
+  register<Target, TSchema extends Schema<Target>>(type: Constructable<Target>, schema?: TSchema) {
     if (!type && !schema) {
       throw new Error('type paramater is required when register a mapping');
     } else if (this.exists(type)) {
@@ -426,7 +431,7 @@ export class MorphismRegistry implements IMorphismRegistry {
    * @param {Schema} schema Class Type of the ouput Data
    *
    */
-  setMapper<Target>(type: Constructable<Target>, schema: Schema) {
+  setMapper<Target>(type: Constructable<Target>, schema: Schema<Target>) {
     if (!schema) {
       throw new Error(`The schema must be an Object. Found ${schema}`);
     } else if (!this.exists(type)) {

--- a/src/morphism.ts
+++ b/src/morphism.ts
@@ -131,6 +131,10 @@ export type ActionSelector = { path: string | string[]; fn: (fieldValue: any, it
  * ```
  */
 type SchemaActions = ActionString | ActionFunction | ActionAggregator | ActionSelector;
+export type StrictSchema<Target> = {
+  /** `destinationProperty` is the name of the property of the target object you want to produce */
+  [destinationProperty in keyof Target]: ActionString | ActionFunction | ActionAggregator | ActionSelector
+};
 export type Schema<Target> = {
   /** `destinationProperty` is the name of the property of the target object you want to produce */
   [destinationProperty in keyof Target]?: ActionString | ActionFunction | ActionAggregator | ActionSelector

--- a/src/morphism.ts
+++ b/src/morphism.ts
@@ -130,14 +130,15 @@ export type ActionSelector = { path: string | string[]; fn: (fieldValue: any, it
  * morphism(schema, input);
  * ```
  */
-export interface Schema {
+type SchemaActions = ActionString | ActionFunction | ActionAggregator | ActionSelector;
+export type Schema<Target> = {
   /** `destinationProperty` is the name of the property of the target object you want to produce */
-  [destinationProperty: string]: ActionString | ActionFunction | ActionAggregator | ActionSelector;
-}
+  [destinationProperty in keyof Target]?: ActionString | ActionFunction | ActionAggregator | ActionSelector
+};
 
 function transformValuesFromObject<TDestination, Source>(
   object: Source,
-  schema: Schema,
+  schema: Schema<TDestination>,
   items: Source[],
   objectToCompute: TDestination
 ): TDestination;

--- a/src/typings.spec.ts
+++ b/src/typings.spec.ts
@@ -1,4 +1,4 @@
-import Morphism, { morphism } from './morphism';
+import Morphism, { morphism, Schema } from './morphism';
 
 describe('Morphism', () => {
   describe('Currying Function overload', () => {
@@ -63,6 +63,20 @@ describe('Morphism', () => {
 
       expect(mapper(source).foo).toEqual('value');
       expect(mapper([source][0]).foo).toEqual('value');
+    });
+  });
+
+  describe('Schema Type Checking', () => {
+    it('Should allow to type the Schema', () => {
+      interface IFoo {
+        foo: string;
+        bar: number;
+      }
+      const schema: Schema<IFoo> = { foo: 'qux' };
+      const source = { qux: 'foo' };
+      const target = morphism(schema, source);
+
+      expect(target.foo).toEqual(source.qux);
     });
   });
 });

--- a/src/typings.spec.ts
+++ b/src/typings.spec.ts
@@ -1,4 +1,4 @@
-import Morphism, { morphism, Schema } from './morphism';
+import Morphism, { morphism, Schema, StrictSchema } from './morphism';
 
 describe('Morphism', () => {
   describe('Currying Function overload', () => {
@@ -77,6 +77,19 @@ describe('Morphism', () => {
       const target = morphism(schema, source);
 
       expect(target.foo).toEqual(source.qux);
+    });
+
+    it('Should allow to use a strict Schema', () => {
+      interface IFoo {
+        foo: string;
+        bar: number;
+      }
+      const schema: StrictSchema<IFoo> = { foo: 'qux', bar: () => 'test' };
+      const source = { qux: 'foo' };
+      const target = morphism(schema, source);
+
+      expect(target.foo).toEqual(source.qux);
+      expect(target.bar).toEqual('test');
     });
   });
 });


### PR DESCRIPTION
## Description
```ts
export type Schema<Target> = {
  /** `destinationProperty` is the name of the property of the target object you want to produce */
  [destinationProperty in keyof Target]?: ActionString | ActionFunction | ActionAggregator | ActionSelector
};
```

<img width="673" alt="screen shot 2018-09-24 at 3 16 26 pm" src="https://user-images.githubusercontent.com/4748419/45975798-1429de80-c013-11e8-813e-259730af4ff6.png">


## Related Issue
Closes #33 
