### PR TITLE
Feat(ES6Class): allow to turn off automapping of class fields

### DIFF
--- a/src/MorphismTree.spec.ts
+++ b/src/MorphismTree.spec.ts
@@ -1,4 +1,4 @@
-import { MophismSchemaTree, SchemaNode, NodeKind } from './MorphismTree';
+import { MorphismSchemaTree, SchemaNode, NodeKind } from './MorphismTree';
 import Morphism, { StrictSchema } from './morphism';
 
 describe('Tree', () => {
@@ -7,7 +7,7 @@ describe('Tree', () => {
       interface Target {
         keyA: string;
       }
-      const tree = new MophismSchemaTree<Target, {}>({});
+      const tree = new MorphismSchemaTree<Target, {}>({});
       tree.add({ action: 'keyA', propertyName: 'keyA' });
 
       const root: SchemaNode<Target, {}> = {
@@ -36,7 +36,7 @@ describe('Tree', () => {
       interface Target {
         keyA: string;
       }
-      const tree = new MophismSchemaTree<Target, {}>({});
+      const tree = new MorphismSchemaTree<Target, {}>({});
       const parentTargetPropertyPath = 'keyA';
       tree.add({ action: null, propertyName: 'keyA', targetPropertyPath: parentTargetPropertyPath });
       tree.add({ action: 'keyA', propertyName: 'keyA1' }, parentTargetPropertyPath);
@@ -74,7 +74,7 @@ describe('Tree', () => {
         keyA: string;
       }
       const schema: StrictSchema<Target> = { keyA: 'test' };
-      const tree = new MophismSchemaTree(schema);
+      const tree = new MorphismSchemaTree(schema);
 
       const expected = {
         propertyName: 'keyA',
@@ -110,7 +110,7 @@ describe('Tree', () => {
         keyA: { keyA1: mockAction },
         keyB: { keyB1: { keyB11: mockAction } }
       };
-      const tree = new MophismSchemaTree(schema);
+      const tree = new MorphismSchemaTree(schema);
 
       const expected = [
         {
@@ -174,7 +174,7 @@ describe('Tree', () => {
       const schema: StrictSchema<Target> = {
         keyA: [{ keyA1: mockAction, keyA2: mockAction }, { keyB1: mockAction, keyB2: mockAction }]
       };
-      const tree = new MophismSchemaTree(schema);
+      const tree = new MorphismSchemaTree(schema);
 
       const expected = [
         {

--- a/src/MorphismTree.spec.ts
+++ b/src/MorphismTree.spec.ts
@@ -1,5 +1,5 @@
-import { MophismSchemaTree, SchemaNode, NodeKind, parseSchema } from './MorphismTree';
-import { StrictSchema } from './morphism';
+import { MophismSchemaTree, SchemaNode, NodeKind } from './MorphismTree';
+import Morphism, { StrictSchema } from './morphism';
 
 describe('Tree', () => {
   describe('Add', () => {
@@ -7,7 +7,7 @@ describe('Tree', () => {
       interface Target {
         keyA: string;
       }
-      const tree = new MophismSchemaTree<Target, {}>();
+      const tree = new MophismSchemaTree<Target, {}>({});
       tree.add({ action: 'keyA', propertyName: 'keyA' });
 
       const root: SchemaNode<Target, {}> = {
@@ -36,7 +36,7 @@ describe('Tree', () => {
       interface Target {
         keyA: string;
       }
-      const tree = new MophismSchemaTree<Target, {}>();
+      const tree = new MophismSchemaTree<Target, {}>({});
       const parentTargetPropertyPath = 'keyA';
       tree.add({ action: null, propertyName: 'keyA', targetPropertyPath: parentTargetPropertyPath });
       tree.add({ action: 'keyA', propertyName: 'keyA1' }, parentTargetPropertyPath);
@@ -74,7 +74,7 @@ describe('Tree', () => {
         keyA: string;
       }
       const schema: StrictSchema<Target> = { keyA: 'test' };
-      const tree = parseSchema(schema);
+      const tree = new MophismSchemaTree(schema);
 
       const expected = {
         propertyName: 'keyA',
@@ -110,7 +110,7 @@ describe('Tree', () => {
         keyA: { keyA1: mockAction },
         keyB: { keyB1: { keyB11: mockAction } }
       };
-      const tree = parseSchema(schema);
+      const tree = new MophismSchemaTree(schema);
 
       const expected = [
         {
@@ -174,7 +174,7 @@ describe('Tree', () => {
       const schema: StrictSchema<Target> = {
         keyA: [{ keyA1: mockAction, keyA2: mockAction }, { keyB1: mockAction, keyB2: mockAction }]
       };
-      const tree = parseSchema(schema);
+      const tree = new MophismSchemaTree(schema);
 
       const expected = [
         {

--- a/src/MorphismTree.ts
+++ b/src/MorphismTree.ts
@@ -60,10 +60,7 @@ export interface SchemaOptions<Target = any> {
  * @param {StrictSchema} schema
  * @param {SchemaOptions<Target>} [options]
  */
-export function createSchema<Target = any, Source = any>(
-  schema: StrictSchema<Target, Source>,
-  options?: SchemaOptions<Target>
-) {
+export function createSchema<Target = any, Source = any>(schema: StrictSchema<Target, Source>, options?: SchemaOptions<Target>) {
   if (options && !isEmptyObject(options)) (schema as any)[SCHEMA_OPTIONS_SYMBOL] = options;
   return schema;
 }
@@ -198,9 +195,7 @@ export class MophismSchemaTree<Target, Source> {
           result = action.fn.call(undefined, value, object, items, objectToCompute);
         } catch (e) {
           e.message = `Unable to set target property [${targetProperty}].
-                                        \n An error occured when applying [${action.fn.name}] on property [${
-            action.path
-          }]
+                                        \n An error occured when applying [${action.fn.name}] on property [${action.path}]
                                         \n Internal error: ${e.message}`;
           throw e;
         }

--- a/src/MorphismTree.ts
+++ b/src/MorphismTree.ts
@@ -66,10 +66,6 @@ export function createSchema<Target = any, Source = any>(schema: StrictSchema<Ta
   return schema;
 }
 
-export function getSchemaOptions(schema: Schema | StrictSchema): SchemaOptions | undefined {
-  return (schema as any)[SCHEMA_OPTIONS_SYMBOL];
-}
-
 export class MorphismSchemaTree<Target, Source> {
   schemaOptions: SchemaOptions<Target>;
 

--- a/src/MorphismTree.ts
+++ b/src/MorphismTree.ts
@@ -164,10 +164,6 @@ export class MophismSchemaTree<Target, Source> {
     }
   }
 
-  getSchemaOptions() {
-    return this.schemaOptions;
-  }
-
   getActionKind(action: Actions<Target, Source> | null) {
     if (isActionString(action)) return NodeKind.ActionString;
     if (isFunction(action)) return NodeKind.ActionFunction;

--- a/src/MorphismTree.ts
+++ b/src/MorphismTree.ts
@@ -50,7 +50,7 @@ type AddNode<Target, Source> = Overwrite<
 export interface SchemaOptions<Target = any> {
   undefinedValues?: {
     strip: boolean;
-    default?(target: Target, propertyPath: string): any;
+    default?: (target: Target, propertyPath: string) => any;
   };
 }
 

--- a/src/MorphismTree.ts
+++ b/src/MorphismTree.ts
@@ -70,30 +70,31 @@ export function getSchemaOptions(schema: Schema | StrictSchema): SchemaOptions |
   return (schema as any)[SCHEMA_OPTIONS_SYMBOL];
 }
 
-export class MophismSchemaTree<Target, Source> {
-  private defaultSchemaOptions: SchemaOptions<Target> = { class: { automapping: true }, undefinedValues: { strip: false } };
+export class MorphismSchemaTree<Target, Source> {
+  schemaOptions: SchemaOptions<Target>;
 
   root: SchemaNode<Target, Source>;
-  schema: Schema | StrictSchema;
+  schema: Schema | StrictSchema | null;
 
-  constructor(schema: Schema | StrictSchema) {
+  constructor(schema: Schema<Target, Source> | StrictSchema<Target, Source> | null) {
     this.schema = schema;
-    (this.schema as any)[SCHEMA_OPTIONS_SYMBOL] = { ...this.defaultSchemaOptions, ...this.schemaOptions };
+    this.schemaOptions = MorphismSchemaTree.getSchemaOptions(this.schema);
 
     this.root = {
       data: { targetPropertyPath: '', propertyName: 'MorphismTreeRoot', action: null, kind: NodeKind.Root },
       parent: null,
       children: []
     };
-    this.parseSchema(schema);
+    if (schema) {
+      this.parseSchema(schema);
+    }
   }
 
-  get schemaOptions(): SchemaOptions<Target> {
-    return (this.schema as any)[SCHEMA_OPTIONS_SYMBOL];
-  }
+  static getSchemaOptions<Target>(schema: Schema | StrictSchema | null): SchemaOptions<Target> {
+    const defaultSchemaOptions: SchemaOptions<Target> = { class: { automapping: true }, undefinedValues: { strip: false } };
+    const options = schema ? (schema as any)[SCHEMA_OPTIONS_SYMBOL] : undefined;
 
-  static getSchemaOptions(schema: Schema | StrictSchema) {
-    return (schema as any)[SCHEMA_OPTIONS_SYMBOL];
+    return { ...defaultSchemaOptions, ...options };
   }
 
   private parseSchema(partialSchema: Partial<Schema | StrictSchema> | string | number, actionKey?: string, parentKeyPath?: string): void {

--- a/src/classObjects.spec.ts
+++ b/src/classObjects.spec.ts
@@ -1,5 +1,6 @@
 import Morphism, { toClassObject, morph, morphism, SCHEMA_OPTIONS_SYMBOL, Schema } from './morphism';
 import { User } from './utils-test';
+import { createSchema } from './MorphismTree';
 
 describe('Class Objects', () => {
   describe('Class Type Mapping', function() {
@@ -171,6 +172,22 @@ describe('Class Objects', () => {
 
       const schema: Schema = { c: 'c', [SCHEMA_OPTIONS_SYMBOL]: { class: { automapping: false } } };
       const result = morphism(schema, source, Target);
+
+      expect(result).toEqual({ c: 'normal' });
+    });
+
+    it('(Registry API) should not automatically map class fields when automapping is turned off', () => {
+      class Target {
+        a: string;
+        b: number;
+        c: string;
+      }
+
+      const source = { a: 'auto', b: 1, c: 'normal' };
+
+      const schema = createSchema({ c: 'c' }, { class: { automapping: false } });
+      Morphism.register(Target, schema);
+      const result = Morphism.map(Target, source);
 
       expect(result).toEqual({ c: 'normal' });
     });

--- a/src/classObjects.spec.ts
+++ b/src/classObjects.spec.ts
@@ -1,6 +1,5 @@
-import Morphism, { toClassObject, morph, morphism } from './morphism';
+import Morphism, { toClassObject, morph, morphism, SCHEMA_OPTIONS_SYMBOL, Schema } from './morphism';
 import { User } from './utils-test';
-import { createSchema } from './MorphismTree';
 
 describe('Class Objects', () => {
   describe('Class Type Mapping', function() {
@@ -159,6 +158,21 @@ describe('Class Objects', () => {
       const result = morphism(schema, source, Target);
 
       expect(result).toEqual(source);
+    });
+
+    it('should not automatically map class fields when automapping is turned off', () => {
+      class Target {
+        a: string;
+        b: number;
+        c: string;
+      }
+
+      const source = { a: 'auto', b: 1, c: 'normal' };
+
+      const schema: Schema = { c: 'c', [SCHEMA_OPTIONS_SYMBOL]: { class: { automapping: false } } };
+      const result = morphism(schema, source, Target);
+
+      expect(result).toEqual({ c: 'normal' });
     });
   });
   describe('Projection', () => {

--- a/src/classObjects.spec.ts
+++ b/src/classObjects.spec.ts
@@ -1,5 +1,6 @@
 import Morphism, { toClassObject, morph, morphism } from './morphism';
 import { User } from './utils-test';
+import { createSchema } from './MorphismTree';
 
 describe('Class Objects', () => {
   describe('Class Type Mapping', function() {
@@ -143,6 +144,21 @@ describe('Class Objects', () => {
 
       let result = Morphism.map(User, mock);
       expect(result.type).toEqual('User');
+    });
+
+    it('should automatically map class fields when source fields match the target', () => {
+      class Target {
+        a: string;
+        b: number;
+        c: string;
+      }
+
+      const source = { a: 'auto', b: 1, c: 'normal' };
+
+      const schema = { c: 'c' };
+      const result = morphism(schema, source, Target);
+
+      expect(result).toEqual(source);
     });
   });
   describe('Projection', () => {

--- a/src/morphism.spec.ts
+++ b/src/morphism.spec.ts
@@ -1,11 +1,4 @@
-import Morphism, {
-  StrictSchema,
-  morphism,
-  Schema,
-  createSchema,
-  SchemaOptions,
-  SCHEMA_OPTIONS_SYMBOL
-} from './morphism';
+import Morphism, { StrictSchema, morphism, Schema, createSchema, SchemaOptions, SCHEMA_OPTIONS_SYMBOL } from './morphism';
 import { User, MockData } from './utils-test';
 import { ActionSelector, ActionAggregator } from './types';
 
@@ -316,8 +309,7 @@ describe('Morphism', () => {
       it('should be resilient when doing nesting mapping and using destructuration on array', function() {
         let nestedSchema = {
           target: 'source',
-          nestedTargets: ({ nestedSources }: any) =>
-            Morphism({ nestedTarget: ({ nestedSource }: any) => nestedSource }, nestedSources)
+          nestedTargets: ({ nestedSources }: any) => Morphism({ nestedTarget: ({ nestedSource }: any) => nestedSource }, nestedSources)
         };
         let schema = {
           complexTarget: ({ complexSource }: any) => Morphism(nestedSchema, complexSource)
@@ -359,7 +351,7 @@ describe('Morphism', () => {
         interface Source {
           s1: string;
         }
-        const options: SchemaOptions = { undefinedValues: { strip: true } };
+        const options: SchemaOptions = { class: { automapping: true }, undefinedValues: { strip: true } };
         const schema = createSchema<Target, Source>({ keyA: 's1' }, options);
         const res = morphism(schema, { s1: 'value' });
 

--- a/src/morphism.ts
+++ b/src/morphism.ts
@@ -94,7 +94,7 @@ function transformItems<T, TSchema extends Schema<T | {}>>(schema: TSchema, type
   return mapper;
 }
 
-function getSchemaForType<T>(type: Constructable<T>, baseSchema: Schema<T>): Schema<T> {
+function getSchemaForClass<T>(type: Constructable<T>, baseSchema: Schema<T>): Schema<T> {
   let typeFields = Object.keys(new type());
   let defaultSchema = zipObject(typeFields, typeFields);
   let finalSchema = Object.assign(defaultSchema, baseSchema);
@@ -162,7 +162,7 @@ function morphism<Target, Source, TSchema extends Schema<Target, Source>>(
     }
     case 3: {
       if (type) {
-        const finalSchema = getSchemaForType(type, schema);
+        const finalSchema = getSchemaForClass(type, schema);
         if (items !== null) return transformItems(finalSchema, type)(items); // TODO: deprecate this option morphism(schema,null,Type) in favor of createSchema({},options={class: Type})
         return transformItems(finalSchema, type);
       } else {

--- a/src/morphism.ts
+++ b/src/morphism.ts
@@ -21,7 +21,7 @@ function transformValuesFromObject<Source, Target>(
   items: Source[],
   objectToCompute: Target
 ) {
-  const options = tree.getSchemaOptions();
+  const options = tree.schemaOptions;
   const transformChunks = [];
 
   for (const node of tree.traverseBFS()) {

--- a/src/morphism.ts
+++ b/src/morphism.ts
@@ -3,7 +3,7 @@
  */
 import { zipObject, isUndefined, get, set, SCHEMA_OPTIONS_SYMBOL } from './helpers';
 import { Schema, StrictSchema, Constructable, SourceFromSchema, Mapper, DestinationFromSchema } from './types';
-import { MophismSchemaTree, parseSchema, createSchema, SchemaOptions } from './MorphismTree';
+import { MophismSchemaTree, createSchema, SchemaOptions } from './MorphismTree';
 import { MorphismRegistry, IMorphismRegistry } from './MorphismRegistry';
 import { decorator } from './MorphismDecorator';
 
@@ -46,7 +46,7 @@ function transformValuesFromObject<Source, Target>(
     const finalValue = undefinedValueCheck(get(finalObject, chunk.targetPropertyPath), chunk.preparedAction);
     if (finalValue === undefined) {
       // strip undefined values
-      if (options.undefinedValues && options.undefinedValues.strip) {
+      if (options && options.undefinedValues && options.undefinedValues.strip) {
         if (options.undefinedValues.default) {
           set(finalObject, chunk.targetPropertyPath, options.undefinedValues.default(finalObject, chunk.targetPropertyPath));
         }
@@ -63,7 +63,7 @@ function transformValuesFromObject<Source, Target>(
 }
 
 function transformItems<T, TSchema extends Schema<T | {}>>(schema: TSchema, type?: Constructable<T>) {
-  const tree = parseSchema(schema);
+  const tree = new MophismSchemaTree(schema);
 
   function mapper(source: any) {
     if (!source) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { SCHEMA_OPTIONS_SYMBOL, SchemaOptions } from './morphism';
+
 /**
  * A structure-preserving object from a source data towards a target data.
  *
@@ -37,7 +39,7 @@ export type StrictSchema<Target = any, Source = any> = {
     | ActionAggregator<Source>
     | ActionSelector<Source, Target[destinationProperty]>
     | StrictSchema<Target[destinationProperty], Source>
-};
+} & { [SCHEMA_OPTIONS_SYMBOL]?: SchemaOptions<Target> };
 export type Schema<Target = any, Source = any> = {
   /** `destinationProperty` is the name of the property of the target object you want to produce */
   [destinationProperty in keyof Target]?:
@@ -46,7 +48,7 @@ export type Schema<Target = any, Source = any> = {
     | ActionAggregator<Source>
     | ActionSelector<Source, Target[destinationProperty]>
     | Schema<Target[destinationProperty], Source>
-};
+} & { [SCHEMA_OPTIONS_SYMBOL]?: SchemaOptions<Target | any> };
 
 export type Actions<Target, Source> = ActionFunction<Target, Source> | ActionAggregator | ActionString<Target> | ActionSelector<Source>;
 


### PR DESCRIPTION
## Description
``` typescript
      class Target {
        a: string;
        b: string;
      }

      const source = { a: 'propA', b: 'propB' };

      const schema = createSchema({ b: 'b' }, { class: { automapping: false } });
      Morphism.register(Target, schema);
      const result = Morphism.map(Target, source);

      expect(result).toEqual({ b: 'propB' });

```


## Related Issue
<!--- Closes #32 where #32 is github number issue-->
