### PR TITLE
feat(package): Make library compatible with IE

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -41,7 +41,28 @@ const webpackconfiguration: webpack.Configuration = {
     extensions: ['.ts', '.tsx', '.js', '.json']
   },
   module: {
-    rules: [{ test: /\.(ts|js)x?$/, use: ['babel-loader', 'source-map-loader'], exclude: /node_modules/ }]
+    rules: [
+      { 
+        test: /\.(ts|js)x?$/, 
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: [
+                [
+                  '@babel/preset-env',
+                  {
+                    exclude: ['@babel/plugin-transform-regenerator']
+                  }
+                ]
+              ]
+            }
+          }, 
+          'source-map-loader'
+        ]
+      }
+    ]
   },
   plugins: [
     new ForkTsCheckerWebpackPlugin({


### PR DESCRIPTION
## Description
Uses the preset-env babel preset in the package webpack config file so the resulting JavaScript works in IE. 
The transform-regenerator plugin has been excluded so babel polyfills do not need to be used in the consuming application.

The @babel/preset-env library is already included in the project, so no package.json changes.

Tested in IE11.

https://babeljs.io/docs/en/babel-preset-env
