### PR TITLE
Fix/typescript type widening on action function

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export type StrictSchema<Target = any, Source = any> = {
   /** `destinationProperty` is the name of the property of the target object you want to produce */
   [destinationProperty in keyof Target]:
     | ActionString<Source>
-    | ActionFunction<Target, Source, Target[destinationProperty]>
+    | { (iteratee: Source, source: Source[], target: Target[destinationProperty]): Target[destinationProperty] }
     | ActionAggregator<Source>
     | ActionSelector<Source, Target>
     | StrictSchema<Target[destinationProperty], Source>;
@@ -44,7 +44,7 @@ export type Schema<Target = any, Source = any> = {
   /** `destinationProperty` is the name of the property of the target object you want to produce */
   [destinationProperty in keyof Target]?:
     | ActionString<Source>
-    | ActionFunction<Target, Source, Target[destinationProperty]>
+    | { (iteratee: Source, source: Source[], target: Target[destinationProperty]): Target[destinationProperty] }
     | ActionAggregator<Source>
     | ActionSelector<Source, Target>
     | Schema<Target[destinationProperty], Source>;

--- a/src/typescript.spec.ts
+++ b/src/typescript.spec.ts
@@ -1,4 +1,4 @@
-import Morphism, { morphism, StrictSchema, Schema } from './morphism';
+import Morphism, { morphism, StrictSchema, Schema, createSchema } from './morphism';
 
 describe('Typescript', () => {
   describe('Registry Type Checking', () => {
@@ -183,6 +183,14 @@ describe('Typescript', () => {
       result.forEach((item, idx) => {
         expect(item).toEqual(expected[idx]);
       });
+    });
+
+    it('should accept union types as Target', () => {
+      const schema = createSchema<{ a: string } | { a: string; b: string }, { c: string }>({
+        a: ({ c }) => c
+      });
+
+      expect(morphism(schema, { c: 'result' }).a).toEqual('result');
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Its must follow the pattern "<type>(<scope>): <subject>" -->
<!--- where <type> can be feat/fix/doc/style/refactor/perf/test/chore -->

## Description

Fix Typescript widening issue on `ActionFunction`

## Related Issue
#148 
